### PR TITLE
Floorceilround

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+vendor
+composer.lock
+.phpunit.result.cache
+.phpunit.cache

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ Qed (pronounced "ked") is a wrapper for BCMath functionality.
 
 It uses method chaining to allow operations to flow from previous operations.
 
+Qed also provides polyfill functions for `bcround`, `bcceil`, and `bcfloor`,
+which are coming in [a future PHP release](https://wiki.php.net/rfc/adding_bcround_bcfloor_bcceil_to_bcmath).
+
 ## Example
 
 **A set of basic operations:**
@@ -18,7 +21,9 @@ echo $num->value; // 600
 
 **Setting the scale:**
 
-BCMath operations have a concept of a "scale factor". This can become quite important - certain numbers may end up being unintentionally truncated if the scale is not set to a suitable value.
+BCMath operations have a concept of a "scale factor". This can become quite
+important - certain numbers may end up being unintentionally truncated if the
+scale is not set to a suitable value.
 
 Scale may be a bit different than precision. For more information, see the [bcscale() documentation](https://www.php.net/manual/en/function.bcscale.php) on the PHP website.
 
@@ -30,4 +35,31 @@ $num = $num->div($divisor)->mul('10');
 echo $num->value; // 2.6973
 ```
 
-Note that the scale follows the left-side of the flow. If a `Qed` object is passed as the divisor (or any other operand), that object's scale will be ignored.
+Note that the scale follows the left-side of the flow. If a `Qed` object is
+passed as the divisor (or any other operand), that object's scale will be
+ignored.
+
+**Rounding:**
+
+While `bcround()` isn't yet available in PHP, Qed provides a polyfill function
+and a helper method. This polyfill function is primitive and deeply unreliable.
+
+But, if you want to risk it, here's how to use it:
+
+```php
+$num = new Qed('123', 10);
+$divisor = new Qed('456');
+$num = $num->div($divisor)->mul('10')->round(2);
+
+echo $num->value; // 2.70
+```
+
+Note that the precision value is NOT the same as a normal "scale" value, because
+scale factor cannot be a negative value (but precision can). The returned Qed
+object will have the same scale value as the originating instance, the precision
+value is only applied to the internals of `bcround`.
+
+There is a second parameter, `$roundHalf`, which can be one of the
+`PHP_ROUND_HALF_*` constants. These are currently ignored in the polyfill, but
+will be functional in the future. See [php.net/round](https://www.php.net/round)
+for more information about how they are expected to work.

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,10 @@
     "autoload": {
         "psr-4": {
             "Whateverthing\\Qed\\": "src/"
-        }
+        },
+        "files": [
+            "qed_polyfill_functions.php"
+        ]
     },
     "authors": [
         {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,7 +4,7 @@
          bootstrap="vendor/autoload.php"
          cacheDirectory=".phpunit.cache"
          executionOrder="depends,defects"
-         requireCoverageMetadata="true"
+         requireCoverageMetadata="false"
          beStrictAboutCoverageMetadata="true"
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"

--- a/qed_polyfill_functions.php
+++ b/qed_polyfill_functions.php
@@ -1,0 +1,80 @@
+<?php
+
+if (!function_exists('bcround')) {
+    function bcround(string $num1, int $precision = 0, int $mode = PHP_ROUND_HALF_UP): string
+    {
+        $symbol = substr($num1, 0, 1) === '-' ? '-' : '';
+        $num1 = ltrim($num1, '-');
+
+        $decimalPos = strpos($num1, '.');
+
+        if (false === $decimalPos) {
+            return $symbol . $num1;
+        }
+
+        $number = substr($num1, 0, $decimalPos);
+        $decimal = substr($num1, $decimalPos + 1, $precision);
+        $remainder = substr($num1, $decimalPos + $precision + 1, 1);
+
+        if ($precision == 0) {
+            if ((int) $remainder >= 5) {
+                return $symbol . bcadd($number, '1');
+            }
+
+            return $symbol . ($number ?: '0');
+        }
+
+        if ((int) $remainder >= 5) {
+            $decimal = bcadd($decimal, '1');
+        }
+
+        return $symbol . ($number ?: 0) . '.' . $decimal;
+    }
+}
+
+if (!function_exists('bcceil')) {
+    function bcceil(string $num): string
+    {
+        $decimalPos = strpos($num, '.');
+
+        if (false === $decimalPos) {
+            return $num;
+        }
+
+        $output = substr($num, 0, $decimalPos) ?: '0';
+
+        if ($output == '-') {
+            return '-0';
+        }
+
+        if (strpos($output, '-') === 0) {
+            return $output;
+        }
+
+        $remainder = substr($num, $decimalPos);
+        if (bccomp($remainder, '0', 100) === '1') {
+            return $output;
+        }
+
+        return bcadd($output, '1');
+    }
+}
+
+if (!function_exists('bcfloor')) {
+    function bcfloor(string $num): string
+    {
+        $decimalPos = strpos($num, '.');
+
+        if (false === $decimalPos) {
+            return $num;
+        }
+
+        $output = substr($num, 0, $decimalPos) ?: '0';
+
+        if ($output == '-') {
+            return '-0';
+        }
+
+        return $output;
+    }
+}

--- a/qed_polyfill_functions.php
+++ b/qed_polyfill_functions.php
@@ -7,26 +7,98 @@ if (!function_exists('bcround')) {
         $num1 = ltrim($num1, '-');
 
         $decimalPos = strpos($num1, '.');
+        $remainderAdjustment = 1;
 
-        if (false === $decimalPos) {
+        if (false === $decimalPos && $precision >= 0) {
             return $sign . $num1;
+        }
+
+        // Special accommodation for negative precision
+        if ($precision < 0) {
+            $remainderAdjustment = 0;
+
+            if (false === $decimalPos) {
+                $decimalPos = strlen($num1);
+            }
         }
 
         $number = substr($num1, 0, $decimalPos);
         $decimal = substr($num1, $decimalPos + 1, $precision);
-        $remainder = substr($num1, $decimalPos + $precision + 1, 1);
+        $remainder = substr($num1, $decimalPos + $precision + $remainderAdjustment, 1);
 
         if ($precision == 0) {
-            if ((int) $remainder >= 5) {
+            if ((int) $remainder > 5) {
                 return $sign . bcadd($number, '1');
+            }
+
+            if ((int) $remainder == 5) {
+                if (PHP_ROUND_HALF_UP == $mode) {
+                    return $sign . bcadd($number, '1');
+                }
+
+                $digit = substr($number, -1);
+                $even = ((int) $digit) % 2 == 0;
+
+                if (PHP_ROUND_HALF_EVEN == $mode && !$even ) {
+                    return $sign . bcadd($number, '1');
+                }
+
+                if (PHP_ROUND_HALF_ODD == $mode && $even ) {
+                    return $sign . bcadd($number, '1');
+                }
             }
 
             return $sign . ($number ?: '0');
         }
 
-        if ((int) $remainder >= 5) {
+        if ($precision < 0) {
+            $slicedNumber = substr($number, 0, strlen($number) + $precision);
+            $paddingLength = strlen($number);
+
+            if ((int) $remainder >= 5) {
+                $slicedNumber = bcadd($slicedNumber,'1');
+
+                if ($paddingLength == abs($precision)) {
+                    $paddingLength++;
+                }
+            }
+
+            $paddedNumber = str_pad($slicedNumber, $paddingLength, '0', STR_PAD_RIGHT);
+
+            // add a 0 so that a paddedNumber like '000' will come out as '0'
+            return $sign . bcadd($paddedNumber, '0');
+        }
+
+        $length = strlen($decimal);
+
+        if ((int) $remainder > 5) {
             $decimal = bcadd($decimal, '1');
         }
+
+        if ((int) $remainder == 5) {
+            if (PHP_ROUND_HALF_UP == $mode) {
+                $decimal = bcadd($decimal, '1');
+            }
+
+            $digit = substr($decimal, -1);
+
+            if ($digit == '') {
+                $digit = substr($number, -1);
+            }
+
+            $even = ((int) $digit) % 2 == 0;
+
+            if (PHP_ROUND_HALF_EVEN == $mode && !$even ) {
+                $decimal = bcadd($decimal, '1');
+            }
+
+            if (PHP_ROUND_HALF_ODD == $mode && $even ) {
+                $decimal = bcadd($decimal, '1');
+            }
+        }
+
+        // re-add leading zeroes, if any
+        $decimal = str_pad($decimal, $length, '0', STR_PAD_LEFT);
 
         return $sign . ($number ?: 0) . '.' . $decimal;
     }

--- a/qed_polyfill_functions.php
+++ b/qed_polyfill_functions.php
@@ -35,25 +35,24 @@ if (!function_exists('bcround')) {
 if (!function_exists('bcceil')) {
     function bcceil(string $num): string
     {
+        $symbol = substr($num, 0, 1) === '-' ? '-' : '';
+        $num = ltrim($num, '-');
+
         $decimalPos = strpos($num, '.');
 
         if (false === $decimalPos) {
-            return $num;
+            return $symbol . $num;
         }
 
         $output = substr($num, 0, $decimalPos) ?: '0';
 
-        if ($output == '-') {
-            return '-0';
-        }
-
-        if (strpos($output, '-') === 0) {
-            return $output;
+        if ($symbol === '-') {
+            return $symbol . $output;
         }
 
         $remainder = substr($num, $decimalPos);
         if (bccomp($remainder, '0', 100) === '1') {
-            return $output;
+            return $symbol . $output;
         }
 
         return bcadd($output, '1');
@@ -63,18 +62,17 @@ if (!function_exists('bcceil')) {
 if (!function_exists('bcfloor')) {
     function bcfloor(string $num): string
     {
+        $symbol = substr($num, 0, 1) === '-' ? '-' : '';
+        $num = ltrim($num, '-');
+
         $decimalPos = strpos($num, '.');
 
         if (false === $decimalPos) {
-            return $num;
+            return $symbol . $num;
         }
 
         $output = substr($num, 0, $decimalPos) ?: '0';
 
-        if ($output == '-') {
-            return '-0';
-        }
-
-        return $output;
+        return $symbol . $output;
     }
 }

--- a/qed_polyfill_functions.php
+++ b/qed_polyfill_functions.php
@@ -3,13 +3,13 @@
 if (!function_exists('bcround')) {
     function bcround(string $num1, int $precision = 0, int $mode = PHP_ROUND_HALF_UP): string
     {
-        $symbol = substr($num1, 0, 1) === '-' ? '-' : '';
+        $sign = substr($num1, 0, 1) === '-' ? '-' : '';
         $num1 = ltrim($num1, '-');
 
         $decimalPos = strpos($num1, '.');
 
         if (false === $decimalPos) {
-            return $symbol . $num1;
+            return $sign . $num1;
         }
 
         $number = substr($num1, 0, $decimalPos);
@@ -18,41 +18,41 @@ if (!function_exists('bcround')) {
 
         if ($precision == 0) {
             if ((int) $remainder >= 5) {
-                return $symbol . bcadd($number, '1');
+                return $sign . bcadd($number, '1');
             }
 
-            return $symbol . ($number ?: '0');
+            return $sign . ($number ?: '0');
         }
 
         if ((int) $remainder >= 5) {
             $decimal = bcadd($decimal, '1');
         }
 
-        return $symbol . ($number ?: 0) . '.' . $decimal;
+        return $sign . ($number ?: 0) . '.' . $decimal;
     }
 }
 
 if (!function_exists('bcceil')) {
     function bcceil(string $num): string
     {
-        $symbol = substr($num, 0, 1) === '-' ? '-' : '';
+        $sign = substr($num, 0, 1) === '-' ? '-' : '';
         $num = ltrim($num, '-');
 
         $decimalPos = strpos($num, '.');
 
         if (false === $decimalPos) {
-            return $symbol . $num;
+            return $sign . $num;
         }
 
         $output = substr($num, 0, $decimalPos) ?: '0';
 
-        if ($symbol === '-') {
-            return $symbol . $output;
+        if ($sign === '-') {
+            return $sign . $output;
         }
 
         $remainder = substr($num, $decimalPos);
         if (bccomp($remainder, '0', 100) === '1') {
-            return $symbol . $output;
+            return $sign . $output;
         }
 
         return bcadd($output, '1');
@@ -62,17 +62,17 @@ if (!function_exists('bcceil')) {
 if (!function_exists('bcfloor')) {
     function bcfloor(string $num): string
     {
-        $symbol = substr($num, 0, 1) === '-' ? '-' : '';
+        $sign = substr($num, 0, 1) === '-' ? '-' : '';
         $num = ltrim($num, '-');
 
         $decimalPos = strpos($num, '.');
 
         if (false === $decimalPos) {
-            return $symbol . $num;
+            return $sign . $num;
         }
 
         $output = substr($num, 0, $decimalPos) ?: '0';
 
-        return $symbol . $output;
+        return $sign . $output;
     }
 }

--- a/src/Qed.php
+++ b/src/Qed.php
@@ -64,7 +64,7 @@ class Qed
      * NOTE: May have some odd thoughts on whether -0 is less than 0
      *
      * @param string|Qed $rightOperand
-     * @return $this
+     * @return static
      */
     public function comp(string|Qed $rightOperand): static
     {
@@ -88,7 +88,7 @@ class Qed
      *
      * @param string|Qed $exponent
      * @param string|Qed $modulus
-     * @return $this
+     * @return static
      */
     public function powmod(string|Qed $exponent, string|Qed $modulus): static
     {
@@ -111,7 +111,7 @@ class Qed
      * NOTE: This *DOES NOT* call the bcscale() method to set system-wide scale value.
      *
      * @param int|string|Qed|null $scale    Set the scale factor; Null returns current scale factor as Qed object
-     * @return $this
+     * @return static
      */
     public function scale(null|int|string|Qed $scale = null): static
     {
@@ -128,5 +128,29 @@ class Qed
         }
 
         return new static($this->value, $scale);
+    }
+
+    public function floor(): static
+    {
+        return new Qed(bcfloor($this->value), $this->scale);
+    }
+
+    public function ceil(): static
+    {
+        return new Qed(bcceil($this->value), $this->scale);
+    }
+
+    /**
+     * Rounds a Qed number to the provided position, possibly using the provided PHP RoundHalf setting
+     *
+     * NOTE: Current polyfill implementation ignores PHP RoundHalf setting unless system bcround() is present
+     *
+     * @param int $precision    Digits of precision after the decimal point
+     * @param int $roundHalf    Directionality of rounding processes
+     * @return static
+     */
+    public function round(int $precision = 0, int $roundHalf = PHP_ROUND_HALF_UP): static
+    {
+        return new Qed(bcround($this->value, $precision, $roundHalf), $this->scale);
     }
 }

--- a/tests/QedTest.php
+++ b/tests/QedTest.php
@@ -236,5 +236,7 @@ class QedTest extends TestCase
         yield 'uh oh-' . $precision => ['.123', $precision, PHP_ROUND_HALF_UP, '0.1'];
         yield 'negatory-' . $precision => ['-123.77', $precision, PHP_ROUND_HALF_UP, '-123.8'];
         yield 'negazero-' . $precision => ['-.77', $precision, PHP_ROUND_HALF_UP, '-0.8'];
+
+        yield 'qed-example' . $precision => ['2.6973', 2, PHP_ROUND_HALF_UP, '2.70'];
     }
 }

--- a/tests/QedTest.php
+++ b/tests/QedTest.php
@@ -163,4 +163,78 @@ class QedTest extends TestCase
         $num = $num->scale(5);
         $this->assertSame('5', $num->scale()->value);
     }
+
+    /**
+     * @dataProvider floorProvider
+     */
+    public function testFloor($number, $expected): void
+    {
+        $num = new Qed($number);
+
+        $this->assertSame($expected, $num->floor()->value);
+    }
+
+    public static function floorProvider()
+    {
+        yield '123' => ['123.77', '123'];
+        yield 'uh oh' => ['.123', '0'];
+        yield 'negatory' => ['-123.77', '-123'];
+        yield 'negazero' => ['-.77', '-0'];
+    }
+
+    /**
+     * @dataProvider ceilProvider
+     */
+    public function testCeil($number, $expected): void
+    {
+        $num = new Qed($number);
+
+        $this->assertSame($expected, $num->ceil()->value);
+    }
+
+    public static function ceilProvider()
+    {
+        yield '123' => ['123.77', '124'];
+        yield 'uh oh' => ['.123', '1'];
+        yield 'negatory' => ['-123.77', '-123'];
+        yield 'negazero' => ['-.77', '-0'];
+    }
+
+    /**
+     * @dataProvider roundProvider
+     */
+    public function testRound($number, $precision, $roundHalf, $expected): void
+    {
+        $num = new Qed($number);
+
+        $this->assertSame($expected, $num->round($precision, $roundHalf)->value);
+    }
+
+    public static function roundProvider()
+    {
+        $precision = 0;
+        yield 'nada' => ['123', $precision, PHP_ROUND_HALF_UP, '123'];
+        yield 'nada-0' => ['123.0000', $precision, PHP_ROUND_HALF_UP, '123'];
+
+        yield '123-up' => ['123.37', $precision, PHP_ROUND_HALF_UP, '123'];
+        yield '123-down' => ['123.37', $precision, PHP_ROUND_HALF_DOWN, '123'];
+        yield '123-even' => ['123.37', $precision, PHP_ROUND_HALF_EVEN, '123'];
+        yield '123-odd' => ['123.37', $precision, PHP_ROUND_HALF_ODD, '123'];
+
+        yield '124-p0' => ['123.77', $precision, PHP_ROUND_HALF_UP, '124'];
+        yield 'uh oh' => ['.123', $precision, PHP_ROUND_HALF_UP, '0'];
+        yield 'negatory' => ['-123.77', $precision, PHP_ROUND_HALF_UP, '-124'];
+        yield 'negazero' => ['-.77', $precision, PHP_ROUND_HALF_UP, '-1'];
+
+        $precision = 1;
+        yield '123-' . $precision . '-up' => ['123.37', $precision, PHP_ROUND_HALF_UP, '123.4'];
+        yield '123-' . $precision . '-down' => ['123.37', $precision, PHP_ROUND_HALF_DOWN, '123.4'];
+        yield '123-' . $precision . '-even' => ['123.37', $precision, PHP_ROUND_HALF_EVEN, '123.4'];
+        yield '123-' . $precision . '-odd' => ['123.37', $precision, PHP_ROUND_HALF_ODD, '123.4'];
+
+        yield '124-' . $precision => ['123.77', $precision, PHP_ROUND_HALF_UP, '123.8'];
+        yield 'uh oh-' . $precision => ['.123', $precision, PHP_ROUND_HALF_UP, '0.1'];
+        yield 'negatory-' . $precision => ['-123.77', $precision, PHP_ROUND_HALF_UP, '-123.8'];
+        yield 'negazero-' . $precision => ['-.77', $precision, PHP_ROUND_HALF_UP, '-0.8'];
+    }
 }

--- a/tests/QedTest.php
+++ b/tests/QedTest.php
@@ -238,5 +238,48 @@ class QedTest extends TestCase
         yield 'negazero-' . $precision => ['-.77', $precision, PHP_ROUND_HALF_UP, '-0.8'];
 
         yield 'qed-example' . $precision => ['2.6973', 2, PHP_ROUND_HALF_UP, '2.70'];
+
+        yield 'manual-example-1a' => ['3.4', 0, PHP_ROUND_HALF_UP, '3'];
+        yield 'manual-example-1b' => ['3.5', 0, PHP_ROUND_HALF_UP, '4'];
+        yield 'manual-example-1c' => ['3.6', 0, PHP_ROUND_HALF_UP, '4'];
+        yield 'manual-example-1d' => ['3.6', 0, PHP_ROUND_HALF_UP, '4'];
+        yield 'manual-example-1e' => ['5.045', 2, PHP_ROUND_HALF_UP, '5.05'];
+        yield 'manual-example-1f' => ['5.055', 2, PHP_ROUND_HALF_UP, '5.06'];
+        yield 'manual-example-1g' => ['345', -2, PHP_ROUND_HALF_UP, '300'];
+        yield 'manual-example-1h' => ['345', -3, PHP_ROUND_HALF_UP, '0'];
+        yield 'manual-example-1i' => ['678', -2, PHP_ROUND_HALF_UP, '700'];
+        yield 'manual-example-1j' => ['678', -3, PHP_ROUND_HALF_UP, '1000'];
+
+        $num = '135.79';
+        yield 'manual-example-2a' => [$num, 3, PHP_ROUND_HALF_UP, '135.79'];
+        yield 'manual-example-2b' => [$num, 2, PHP_ROUND_HALF_UP, '135.79'];
+        yield 'manual-example-2c' => [$num, 1, PHP_ROUND_HALF_UP, '135.8'];
+        yield 'manual-example-2d' => [$num, 0, PHP_ROUND_HALF_UP, '136'];
+        yield 'manual-example-2e' => [$num, -1, PHP_ROUND_HALF_UP, '140'];
+        yield 'manual-example-2f' => [$num, -2, PHP_ROUND_HALF_UP, '100'];
+        yield 'manual-example-2g' => [$num, -3, PHP_ROUND_HALF_UP, '0'];
+
+        $num = '9.5';
+        yield 'manual-example-3a' => [$num, 0, PHP_ROUND_HALF_UP, '10'];
+        yield 'manual-example-3b' => [$num, 0, PHP_ROUND_HALF_DOWN, '9'];
+        yield 'manual-example-3c' => [$num, 0, PHP_ROUND_HALF_EVEN, '10'];
+        yield 'manual-example-3d' => [$num, 0, PHP_ROUND_HALF_ODD, '9'];
+
+        $num = '8.5';
+        yield 'manual-example-3e' => [$num, 0, PHP_ROUND_HALF_UP, '9'];
+        yield 'manual-example-3f' => [$num, 0, PHP_ROUND_HALF_DOWN, '8'];
+        yield 'manual-example-3g' => [$num, 0, PHP_ROUND_HALF_EVEN, '8'];
+        yield 'manual-example-3h' => [$num, 0, PHP_ROUND_HALF_ODD, '9'];
+
+        $numPos = '1.55';
+        $numNeg = '-' . $numPos;
+        yield 'manual-example-4a' => [$numPos, 1, PHP_ROUND_HALF_UP, '1.6'];
+        yield 'manual-example-4b' => [$numNeg, 1, PHP_ROUND_HALF_UP, '-1.6'];
+        yield 'manual-example-4c' => [$numPos, 1, PHP_ROUND_HALF_DOWN, '1.5'];
+        yield 'manual-example-4d' => [$numNeg, 1, PHP_ROUND_HALF_DOWN, '-1.5'];
+        yield 'manual-example-4e' => [$numPos, 1, PHP_ROUND_HALF_EVEN, '1.6'];
+        yield 'manual-example-4f' => [$numNeg, 1, PHP_ROUND_HALF_EVEN, '-1.6'];
+        yield 'manual-example-4g' => [$numPos, 1, PHP_ROUND_HALF_ODD, '1.5'];
+        yield 'manual-example-4h' => [$numNeg, 1, PHP_ROUND_HALF_ODD, '-1.5'];
     }
 }


### PR DESCRIPTION
Add hackneyed BCMath support for floor, ceil, round operations, in preparation for the [upcoming RFC](https://wiki.php.net/rfc/adding_bcround_bcfloor_bcceil_to_bcmath)

- Adds ->floor(), ->ceil(), ->round() methods to Qed
- Adds polyfills for bcfloor, bcceil, bcround
  - **CAUTION:** These polyfills are truly, embarassingly terrible. Little more than placeholders. DO NOT RELY ON THEM. (Please help fix them.)
- Adds some basic preliminary tests

Addresses Issue #1 